### PR TITLE
Bind backspace silently

### DIFF
--- a/key_bindings.fish
+++ b/key_bindings.fish
@@ -2,7 +2,7 @@
 bind --sets-mode expand \t expand:execute
 
 # During expansion, bind Backspace to revert the operation.
-bind --mode expand --sets-mode default --key backspace expand:revert
+bind --mode expand --sets-mode default --key backspace --silent expand:revert
 
 # Bind Tab to cycle through the available expansions.
 bind --mode expand \t expand:choose-next
@@ -13,6 +13,6 @@ bind --mode expand --sets-mode default '' ''
 # vi mode workaround
 # vi mode shall return to insert mode instead of the default mode
 bind --mode insert --sets-mode vi_expand \t expand:execute
-bind --mode vi_expand --sets-mode insert --key backspace expand:revert
+bind --mode vi_expand --sets-mode insert --key backspace --silent expand:revert
 bind --mode vi_expand \t expand:choose-next
 bind --mode vi_expand --sets-mode insert '' ''


### PR DESCRIPTION
Silences failing bind commands when terminfo has no backspace key defined.
Related to https://github.com/fish-shell/fish-shell/issues/4188

To verify `ssh localhost true` without and with the patch applied.